### PR TITLE
Optimise Gateway State Generation

### DIFF
--- a/src/constant.rs
+++ b/src/constant.rs
@@ -9,7 +9,7 @@ pub const MAX_TX_RECEIPT_RETRIES: u8 = 5;
 pub const MAX_RETRY_ON_PROVIDER_ERROR: u8 = 5;
 
 pub const GATEWAY_BLOCK_STATES_TO_MAINTAIN: u64 = 5;
-pub const WAIT_BEFORE_CHECKING_BLOCK: u64 = 5;
+pub const WAIT_BEFORE_CHECKING_BLOCK: u64 = 100;
 
 lazy_static! {
     pub static ref MIN_GATEWAY_STAKE: U256 = U256::from(111_111_111_111_111_110_000 as u128);


### PR DESCRIPTION
- Update sleep duration for block number retrieval and confirmation delay to use milliseconds instead of seconds.
- Improve block rate per second calculation by using the first recorded block timestamp.
- Adjust block number calculation based on the block rate per second.